### PR TITLE
[Utils] Fix coordinate scaling rounding

### DIFF
--- a/skyvern/utils/image_resizer.py
+++ b/skyvern/utils/image_resizer.py
@@ -55,7 +55,24 @@ def scale_coordinates(
     current_dimension: Resolution,
     target_dimension: Resolution,
 ) -> tuple[int, int]:
+    """Scale a set of coordinates to a new resolution.
+
+    This helper adjusts ``current_coordinates`` so that they maintain the same
+    relative position when the containing image is resized from
+    ``current_dimension`` to ``target_dimension``. The calculation rounds to the
+    nearest integer instead of simply truncating the result which previously
+    caused noticeable drift when downscaling images.
+
+    Args:
+        current_coordinates: The ``(x, y)`` coordinates relative to the current
+            image size.
+        current_dimension: The width and height of the current image.
+        target_dimension: The desired width and height after resizing.
+
+    Returns:
+        tuple[int, int]: The coordinates scaled to ``target_dimension``.
+    """
     return (
-        int(current_coordinates[0] * target_dimension["width"] / current_dimension["width"]),
-        int(current_coordinates[1] * target_dimension["height"] / current_dimension["height"]),
+        round(current_coordinates[0] * target_dimension["width"] / current_dimension["width"]),
+        round(current_coordinates[1] * target_dimension["height"] / current_dimension["height"]),
     )

--- a/tests/unit_tests/test_image_resizer.py
+++ b/tests/unit_tests/test_image_resizer.py
@@ -1,0 +1,21 @@
+"""Tests for :mod:`skyvern.utils.image_resizer` without importing the full package."""
+
+from importlib import util
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[2] / "skyvern" / "utils" / "image_resizer.py"
+spec = util.spec_from_file_location("image_resizer", module_path)
+image_resizer = util.module_from_spec(spec)
+assert spec.loader is not None  # for type checkers
+spec.loader.exec_module(image_resizer)
+
+Resolution = image_resizer.Resolution
+scale_coordinates = image_resizer.scale_coordinates
+
+
+def test_scale_coordinates_rounds_to_nearest_int() -> None:
+    """Coordinates should be rounded when scaling between resolutions."""
+    current_dim = Resolution(width=300, height=300)
+    target_dim = Resolution(width=200, height=200)
+    # 199 * 200 / 300 = 132.666... which should round to 133
+    assert scale_coordinates((199, 199), current_dim, target_dim) == (133, 133)


### PR DESCRIPTION
## Summary
- improve coordinate scaling in `scale_coordinates` by rounding rather than truncating
- add regression test for coordinate scaling rounding

## Testing
- `pytest tests/unit_tests/test_image_resizer.py`
- `pre-commit run --all-files` *(fails: ShellCheck v0.10.0 - Executable `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911340c5d4832b91b4c0b3e60adae8