### PR TITLE
Add user-scoped workflow tagging and organization mapping

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -8,6 +8,7 @@ RUN npm install
 ENV VITE_API_BASE_URL=http://localhost:8000/api/v1
 ENV VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
 ENV VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
+ENV VITE_LICENSE_SERVER_URL=http://localhost:3000
 
 CMD [ "/bin/bash", "/app/entrypoint-skyvernui.sh" ]
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ Start the Skyvern service and UI
 skyvern run all
 ```
 
-Go to http://localhost:8080 and use the UI to run a task
+Go to http://localhost:8080 to access the landing page and click **Login**.
+Enter a product license key issued by your licensing server; the UI
+validates the key remotely and the backend provisions a user and
+organization on first use. All workflows, tasks, credentials and
+artifacts are tied to the returned `organizationID` (stored as
+`organization_id` in the database). The bootstrap credentials supplied
+via `INITIAL_USER_USERNAME`/`INITIAL_USER_PASSWORD` are mapped to
+*organization-1*; each new license login receives *organization-2*,
+*organization-3*, and so on. A logout button in the dashboard clears the
+session when finished.
 
 #### Code
 

--- a/alembic/versions/2025_08_02_1200-3f5b4e6a9c2d_add_user_client_mapping_and_user_ids.py
+++ b/alembic/versions/2025_08_02_1200-3f5b4e6a9c2d_add_user_client_mapping_and_user_ids.py
@@ -1,0 +1,46 @@
+"""Add user-client mapping table and user_id columns to workflows and workflow_runs
+
+Revision ID: 3f5b4e6a9c2d
+Revises: 1eedd7a957d1
+Create Date: 2025-08-02 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3f5b4e6a9c2d"
+down_revision: Union[str, None] = "1eedd7a957d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create user_clients table and add user_id columns."""
+    op.create_table(
+        "user_clients",
+        sa.Column("user_id", sa.String(), primary_key=True),
+        sa.Column("organization_id", sa.String(), sa.ForeignKey("organizations.organization_id"), nullable=False),
+    )
+    op.create_index(op.f("ix_user_clients_organization_id"), "user_clients", ["organization_id"], unique=False)
+
+    op.add_column("workflows", sa.Column("user_id", sa.String(), nullable=True))
+    op.create_index(op.f("ix_workflows_user_id"), "workflows", ["user_id"], unique=False)
+
+    op.add_column("workflow_runs", sa.Column("user_id", sa.String(), nullable=True))
+    op.create_index(op.f("ix_workflow_runs_user_id"), "workflow_runs", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop user_clients table and user_id columns."""
+    op.drop_index(op.f("ix_workflow_runs_user_id"), table_name="workflow_runs")
+    op.drop_column("workflow_runs", "user_id")
+
+    op.drop_index(op.f("ix_workflows_user_id"), table_name="workflows")
+    op.drop_column("workflows", "user_id")
+
+    op.drop_index(op.f("ix_user_clients_organization_id"), table_name="user_clients")
+    op.drop_table("user_clients")

--- a/alembic/versions/2025_08_02_1215-0d8bdb45b4c3_add_users_table.py
+++ b/alembic/versions/2025_08_02_1215-0d8bdb45b4c3_add_users_table.py
@@ -1,0 +1,30 @@
+"""add users table
+
+Revision ID: 0d8bdb45b4c3
+Revises: 3f5b4e6a9c2d
+Create Date: 2025-08-02 12:15:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0d8bdb45b4c3"
+down_revision: Union[str, None] = "3f5b4e6a9c2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add users table."""
+    op.create_table(
+        "users",
+        sa.Column("username", sa.String(), primary_key=True),
+        sa.Column("password_hash", sa.String(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop users table."""
+    op.drop_table("users")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ services:
       timeout: 5s
       retries: 5
   skyvern:
-    image: public.ecr.aws/skyvern/skyvern:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: skyvern:local
     restart: on-failure
     env_file:
       - .env
@@ -39,6 +42,9 @@ services:
       - DATABASE_STRING=postgresql+psycopg://skyvern:skyvern@postgres:5432/skyvern
       - BROWSER_TYPE=chromium-headful
       - ENABLE_CODE_BLOCK=true
+      - INITIAL_USER_USERNAME=admin # maps to organization-1
+      - INITIAL_USER_PASSWORD=admin
+      - LICENSE_SERVER_URL=http://localhost:3000
       # - BROWSER_TYPE=cdp-connect
       # Use this command to start Chrome with remote debugging:
       # "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="C:\chrome-cdp-profile" --no-first-run --no-default-browser-check
@@ -131,7 +137,10 @@ services:
       timeout: 5s
       retries: 5
   skyvern-ui:
-    image: public.ecr.aws/skyvern/skyvern-ui:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    image: skyvern-ui:local
     restart: on-failure
     ports:
       - 8080:8080

--- a/skyvern-frontend/.env.example
+++ b/skyvern-frontend/.env.example
@@ -10,6 +10,9 @@ VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
 # your api key - for x-api-key header
 VITE_SKYVERN_API_KEY=YOUR_API_KEY
 
+# licensing server
+VITE_LICENSE_SERVER_URL=http://localhost:3000
+
 # Enable recording skyvern logs as artifacts
 VITE_ENABLE_LOG_ARTIFACTS=false
 

--- a/skyvern-frontend/README.md
+++ b/skyvern-frontend/README.md
@@ -35,6 +35,13 @@ npm start
 ```
 
 This will build the app and serve from port 8080.
+After launching, visit `http://localhost:8080` and click **Login** on the
+landing page. Supply a valid product license key, which is verified
+against the licensing server. On first use, the backend provisions an
+organization for the email tied to the key. All workflows, tasks,
+credentials and artifacts are scoped to the returned `organizationID`.
+The dashboard exposes a logout control in the top bar to clear the
+session when finished.
 
 ## Development
 

--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { Navigate, Outlet, createBrowserRouter } from "react-router-dom";
 import { BrowserSession } from "@/routes/browserSession/BrowserSession";
 import { PageLayout } from "./components/PageLayout";
@@ -25,23 +26,47 @@ import { WorkflowRunOutput } from "./routes/workflows/workflowRun/WorkflowRunOut
 import { WorkflowRunOverview } from "./routes/workflows/workflowRun/WorkflowRunOverview";
 import { WorkflowRunRecording } from "./routes/workflows/workflowRun/WorkflowRunRecording";
 import { DebugStoreProvider } from "@/store/DebugStoreContext";
+import { LoginPage } from "./routes/login/LoginPage";
+import { RegisterPage } from "./routes/register/RegisterPage";
+import { LandingPage } from "./routes/landing/LandingPage";
+import { useAuthStore } from "@/store/AuthStore";
+
+const ProtectedRoot = () => {
+  const token = useAuthStore((s) => s.token);
+  if (!token) {
+    return <Navigate to="/login" />;
+  }
+  return (
+    <DebugStoreProvider>
+      <RootLayout />
+    </DebugStoreProvider>
+  );
+};
 
 const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <LandingPage />,
+  },
+  {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
+    path: "/register",
+    element: <RegisterPage />,
+  },
   {
     path: "browser-session/:browserSessionId",
     element: <BrowserSession />,
   },
   {
-    path: "/",
-    element: (
-      <DebugStoreProvider>
-        <RootLayout />
-      </DebugStoreProvider>
-    ),
+    path: "/dashboard",
+    element: <ProtectedRoot />,
     children: [
       {
         index: true,
-        element: <Navigate to="/discover" />,
+        element: <Navigate to="discover" />,
       },
       {
         path: "tasks",

--- a/skyvern-frontend/src/routes/landing/LandingPage.tsx
+++ b/skyvern-frontend/src/routes/landing/LandingPage.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+const LandingPage = () => {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center justify-between p-4 shadow">
+        <h1 className="text-xl font-bold">Skyvern</h1>
+        <Link to="/login" className="text-blue-600">
+          Login
+        </Link>
+      </header>
+      <main className="flex flex-1 items-center justify-center">
+        <div className="text-center">
+          <h2 className="mb-4 text-2xl font-semibold">
+            Automation for Professionals
+          </h2>
+          <p className="text-gray-600">
+            Manage workflows securely in your private environment.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export { LandingPage };

--- a/skyvern-frontend/src/routes/login/LoginPage.tsx
+++ b/skyvern-frontend/src/routes/login/LoginPage.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { getClient } from "@/api/AxiosClient";
+import { useAuthStore } from "@/store/AuthStore";
+
+function LoginPage() {
+  const [licenseKey, setLicenseKey] = useState("");
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const client = await getClient(null);
+    const { data } = await client.post("/auth/login", {
+      license_key: licenseKey,
+    });
+    setAuth(data.access_token, data.organizationID);
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="flex w-80 flex-col gap-4">
+        <input
+          value={licenseKey}
+          onChange={(e) => setLicenseKey(e.target.value)}
+          placeholder="License Key"
+          className="rounded p-2 text-black"
+        />
+        <button type="submit" className="rounded bg-blue-600 p-2 text-white">
+          Sign in
+        </button>
+        <Link to="/register" className="text-center text-sm underline">
+          Need a license? Register
+        </Link>
+      </form>
+    </div>
+  );
+}
+
+export { LoginPage };

--- a/skyvern-frontend/src/routes/register/RegisterPage.tsx
+++ b/skyvern-frontend/src/routes/register/RegisterPage.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+
+function RegisterPage() {
+  const portal = import.meta.env.VITE_LICENSE_SERVER_URL;
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-96 space-y-4 text-center">
+        <p>
+          Register for Skyvern using the licensing console available at{" "}
+          <a
+            href={portal}
+            className="text-blue-600"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {portal}
+          </a>
+          . After creating and activating a product license key, return here to
+          sign in with that key.
+        </p>
+        <Link to="/login" className="rounded bg-blue-600 px-4 py-2 text-white">
+          Go to sign in
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export { RegisterPage };

--- a/skyvern-frontend/src/routes/root/Header.tsx
+++ b/skyvern-frontend/src/routes/root/Header.tsx
@@ -1,7 +1,8 @@
 import { DiscordLogoIcon } from "@radix-ui/react-icons";
 import GitHubButton from "react-github-btn";
-import { Link, useMatch, useSearchParams } from "react-router-dom";
+import { Link, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { NavigationHamburgerMenu } from "./NavigationHamburgerMenu";
+import { useAuthStore } from "@/store/AuthStore";
 
 function Header() {
   const [searchParams] = useSearchParams();
@@ -11,15 +12,26 @@ function Header() {
     location.pathname.includes("debug") ||
     embed === "true";
 
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const navigate = useNavigate();
+
   if (match) {
     return null;
   }
+
+  const handleLogout = () => {
+    setAuth(null, null);
+    navigate("/login");
+  };
 
   return (
     <header>
       <div className="flex h-24 items-center px-6">
         <NavigationHamburgerMenu />
         <div className="ml-auto flex gap-4">
+          <button onClick={handleLogout} className="text-sm underline">
+            Logout
+          </button>
           <Link
             to="https://discord.com/invite/fG2XXEuQX3"
             target="_blank"

--- a/skyvern-frontend/src/store/AuthStore.ts
+++ b/skyvern-frontend/src/store/AuthStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import {
+  setAuthorizationHeader,
+  removeAuthorizationHeader,
+} from "@/api/AxiosClient";
+
+type AuthState = {
+  token: string | null;
+  organizationID: string | null;
+  setAuth: (token: string | null, organizationID: string | null) => void;
+  getToken: () => string | null;
+  getOrganizationID: () => string | null;
+};
+
+const initialToken =
+  typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
+const initialOrg =
+  typeof window !== "undefined" ? localStorage.getItem("organizationID") : null;
+if (initialToken) {
+  setAuthorizationHeader(initialToken);
+}
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  token: initialToken,
+  organizationID: initialOrg,
+  setAuth: (token, organizationID) => {
+    if (token) {
+      localStorage.setItem("authToken", token);
+      setAuthorizationHeader(token);
+    } else {
+      localStorage.removeItem("authToken");
+      removeAuthorizationHeader();
+    }
+    if (organizationID) {
+      localStorage.setItem("organizationID", organizationID);
+    } else {
+      localStorage.removeItem("organizationID");
+    }
+    set({ token, organizationID });
+  },
+  getToken: () => get().token,
+  getOrganizationID: () => get().organizationID,
+}));

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -60,6 +60,12 @@ class Settings(BaseSettings):
     SIGNATURE_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # one week
 
+    # Initial user credentials for bootstrapping
+    INITIAL_USER_USERNAME: str | None = None
+    INITIAL_USER_PASSWORD: str | None = None
+    # Remote licensing server URL
+    LICENSE_SERVER_URL: str = "http://localhost:3000"
+
     # Artifact storage settings
     ARTIFACT_STORAGE_PATH: str = f"{SKYVERN_DIR}/artifacts"
     GENERATE_PRESIGNED_URLS: bool = False

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -180,6 +180,20 @@ class OrganizationAuthTokenModel(Base):
     deleted_at = Column(DateTime, nullable=True)
 
 
+class UserClientModel(Base):
+    __tablename__ = "user_clients"
+
+    user_id = Column(String, primary_key=True)
+    organization_id = Column(String, ForeignKey("organizations.organization_id"), index=True, nullable=False)
+
+
+class UserModel(Base):
+    __tablename__ = "users"
+
+    username = Column(String, primary_key=True)
+    password_hash = Column(String, nullable=False)
+
+
 class ArtifactModel(Base):
     __tablename__ = "artifacts"
     __table_args__ = (
@@ -224,6 +238,7 @@ class WorkflowModel(Base):
 
     workflow_id = Column(String, primary_key=True, default=generate_workflow_id)
     organization_id = Column(String, ForeignKey("organizations.organization_id"))
+    user_id = Column(String, index=True, nullable=True)
     title = Column(String, nullable=False)
     description = Column(String, nullable=True)
     workflow_definition = Column(JSON, nullable=False)
@@ -263,6 +278,7 @@ class WorkflowRunModel(Base):
     # workfow runs with parent_workflow_run_id are nested workflow runs which won't show up in the workflow run history
     parent_workflow_run_id = Column(String, nullable=True, index=True)
     organization_id = Column(String, nullable=False, index=True)
+    user_id = Column(String, index=True, nullable=True)
     browser_session_id = Column(String, nullable=True, index=True)
     status = Column(String, nullable=False)
     failure_reason = Column(String)

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -237,6 +237,7 @@ def convert_to_workflow(workflow_model: WorkflowModel, debug_enabled: bool = Fal
     return Workflow(
         workflow_id=workflow_model.workflow_id,
         organization_id=workflow_model.organization_id,
+        user_id=workflow_model.user_id,
         title=workflow_model.title,
         workflow_permanent_id=workflow_model.workflow_permanent_id,
         webhook_callback_url=workflow_model.webhook_callback_url,
@@ -273,6 +274,7 @@ def convert_to_workflow_run(
         parent_workflow_run_id=workflow_run_model.parent_workflow_run_id,
         workflow_id=workflow_run_model.workflow_id,
         organization_id=workflow_run_model.organization_id,
+        user_id=workflow_run_model.user_id,
         browser_session_id=workflow_run_model.browser_session_id,
         status=WorkflowRunStatus[workflow_run_model.status],
         failure_reason=workflow_run_model.failure_reason,

--- a/skyvern/forge/sdk/routes/__init__.py
+++ b/skyvern/forge/sdk/routes/__init__.py
@@ -1,4 +1,5 @@
 from skyvern.forge.sdk.routes import agent_protocol  # noqa: F401
+from skyvern.forge.sdk.routes import auth  # noqa: F401
 from skyvern.forge.sdk.routes import browser_sessions  # noqa: F401
 from skyvern.forge.sdk.routes import credentials  # noqa: F401
 from skyvern.forge.sdk.routes import projects  # noqa: F401

--- a/skyvern/forge/sdk/routes/auth.py
+++ b/skyvern/forge/sdk/routes/auth.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+from hashlib import sha256
+
+import httpx
+from fastapi import HTTPException, status
+from jose import jwt
+from pydantic import BaseModel, ConfigDict, Field
+
+from skyvern.config import settings
+from skyvern.forge import app
+from skyvern.forge.sdk.routes.routers import base_router
+from skyvern.utils.fingerprint import SYSTEM_FINGERPRINT
+
+
+class LicenseLoginRequest(BaseModel):
+    """Request body containing a license key."""
+
+    license_key: str
+
+
+class TokenResponse(BaseModel):
+    """Response containing a JWT access token and organization mapping."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    access_token: str
+    organization_id: str = Field(alias="organizationID")
+    token_type: str = "bearer"
+
+
+@base_router.post("/auth/login", response_model=TokenResponse)
+async def login(data: LicenseLoginRequest) -> TokenResponse:
+    """Validate a license key and issue an access token."""
+    username: str
+    if (
+        settings.INITIAL_USER_USERNAME
+        and settings.INITIAL_USER_PASSWORD
+        and data.license_key == settings.INITIAL_USER_PASSWORD
+    ):
+        username = settings.INITIAL_USER_USERNAME
+        user = await app.DATABASE.get_user(username)
+        if not user:
+            hashed = sha256(data.license_key.encode()).hexdigest()
+            await app.DATABASE.create_user(username, hashed)
+    else:
+        try:
+            response = httpx.post(
+                f"{settings.LICENSE_SERVER_URL}/api/license/validate",
+                json={
+                    "licenseKey": data.license_key,
+                    "machineId": SYSTEM_FINGERPRINT,
+                    "productId": 1,
+                },
+                timeout=10.0,
+            )
+            payload = response.json()
+        except Exception as exc:  # pragma: no cover - network error
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+        if str(payload.get("valid")).lower() != "true":
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license")
+        username = payload["user"]["email"]
+        hashed = sha256(data.license_key.encode()).hexdigest()
+        if not await app.DATABASE.get_user(username):
+            await app.DATABASE.create_user(username, hashed)
+    org = await app.DATABASE.get_or_create_user_org(username)
+    expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    token = jwt.encode(
+        {"sub": username, "exp": expire}, settings.SECRET_KEY, algorithm=settings.SIGNATURE_ALGORITHM
+    )
+    return TokenResponse(access_token=token, organization_id=org.organization_id)

--- a/skyvern/forge/sdk/routes/run_blocks.py
+++ b/skyvern/forge/sdk/routes/run_blocks.py
@@ -70,6 +70,7 @@ async def login(
     background_tasks: BackgroundTasks,
     login_request: LoginRequest,
     organization: Organization = Depends(org_auth_service.get_current_org),
+    current_user_id: str = Depends(org_auth_service.get_current_user_id),
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> WorkflowRunResponse:
     # 1. create empty workflow with a credential parameter
@@ -80,6 +81,7 @@ async def login(
         max_screenshot_scrolling_times=login_request.max_screenshot_scrolling_times,
         extra_http_headers=login_request.extra_http_headers,
         status=WorkflowStatus.auto_generated,
+        user_id=current_user_id,
     )
     # 2. add a login block to the workflow
     label = "login"
@@ -155,6 +157,7 @@ async def login(
     )
     workflow = await app.WORKFLOW_SERVICE.create_workflow_from_request(
         organization=organization,
+        user_id=current_user_id,
         request=workflow_create_request,
         workflow_permanent_id=new_workflow.workflow_permanent_id,
     )

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -65,6 +65,7 @@ class WorkflowStatus(StrEnum):
 class Workflow(BaseModel):
     workflow_id: str
     organization_id: str
+    user_id: str | None = None
     title: str
     workflow_permanent_id: str
     version: int
@@ -111,6 +112,7 @@ class WorkflowRun(BaseModel):
     workflow_id: str
     workflow_permanent_id: str
     organization_id: str
+    user_id: str | None = None
     browser_session_id: str | None = None
     status: WorkflowRunStatus
     extra_http_headers: dict[str, str] | None = None

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -20,9 +20,22 @@ async def prepare_workflow(
     version: int | None = None,
     max_steps: int | None = None,
     request_id: str | None = None,
+    user_id: str | None = None,
 ) -> WorkflowRun:
-    """
-    Prepare a workflow to be run.
+    """Prepare a workflow to be executed.
+
+    Args:
+        workflow_id: Permanent identifier for the workflow.
+        organization: Organization running the workflow.
+        workflow_request: Definition and configuration for the run.
+        template: Whether the workflow is a template.
+        version: Specific workflow version to execute.
+        max_steps: Maximum steps override.
+        request_id: Optional identifier for tracing the request.
+        user_id: User initiating the workflow.
+
+    Returns:
+        The prepared workflow run record.
     """
     if template:
         if workflow_id not in await app.STORAGE.retrieve_global_workflows():
@@ -36,6 +49,7 @@ async def prepare_workflow(
         version=version,
         max_steps_override=max_steps,
         is_template_workflow=template,
+        user_id=user_id,
     )
 
     workflow = await app.WORKFLOW_SERVICE.get_workflow_by_permanent_id(
@@ -68,7 +82,27 @@ async def run_workflow(
     request_id: str | None = None,
     request: Request | None = None,
     background_tasks: BackgroundTasks | None = None,
+    user_id: str | None = None,
 ) -> WorkflowRun:
+    """Execute a workflow run asynchronously.
+
+    Args:
+        workflow_id: Permanent workflow identifier.
+        organization: Organization running the workflow.
+        workflow_request: Definition and configuration for the run.
+        template: Whether the workflow is a template.
+        version: Specific workflow version to execute.
+        max_steps: Maximum step override.
+        api_key: API key used for execution.
+        request_id: Optional request identifier.
+        request: Incoming HTTP request context.
+        background_tasks: FastAPI background tasks manager.
+        user_id: User initiating the workflow.
+
+    Returns:
+        The executed workflow run record.
+    """
+
     workflow_run = await prepare_workflow(
         workflow_id=workflow_id,
         organization=organization,
@@ -77,6 +111,7 @@ async def run_workflow(
         version=version,
         max_steps=max_steps,
         request_id=request_id,
+        user_id=user_id,
     )
 
     await AsyncExecutorFactory.get_executor().execute_workflow(

--- a/skyvern/utils/fingerprint.py
+++ b/skyvern/utils/fingerprint.py
@@ -1,0 +1,71 @@
+import hashlib
+import platform
+import subprocess
+import uuid
+from typing import List
+
+
+def get_mac() -> str:
+    """Return the device MAC address."""
+    mac = uuid.getnode()
+    return ":".join(f"{(mac >> ele) & 0xff:02x}" for ele in range(40, -1, -8))
+
+
+def get_cpu_id() -> str:
+    """Return a CPU identifier for the current platform."""
+    try:
+        system = platform.system()
+        if system == "Windows":
+            result = subprocess.check_output(["wmic", "cpu", "get", "ProcessorId"]).decode()
+            return result.strip().split("\n")[1].strip()
+        if system == "Linux":
+            result = subprocess.check_output(
+                "cat /proc/cpuinfo | grep Serial", shell=True
+            ).decode()
+            return result.strip().split(":")[1].strip()
+        if system == "Darwin":
+            result = subprocess.check_output(
+                ["sysctl", "-n", "machdep.cpu.brand_string"]
+            ).decode()
+            return result.strip()
+    except Exception:
+        return "unknown-cpu"
+
+
+def get_disk_serial() -> str:
+    """Return the primary disk serial number."""
+    try:
+        system = platform.system()
+        if system == "Windows":
+            result = subprocess.check_output(["wmic", "diskdrive", "get", "SerialNumber"]).decode()
+            lines = result.strip().split("\n")
+            return lines[1].strip()
+        if system == "Linux":
+            result = subprocess.check_output(
+                "sudo hdparm -I /dev/sda | grep 'Serial Number'", shell=True
+            ).decode()
+            return result.strip().split(":")[1].strip()
+        if system == "Darwin":
+            result = subprocess.check_output(
+                "system_profiler SPStorageDataType | grep 'Serial Number'",
+                shell=True,
+            ).decode()
+            return result.strip().split(":")[1].strip()
+    except Exception:
+        return "unknown-disk"
+
+
+def generate_fingerprint() -> str:
+    """Generate a SHA-256 fingerprint of hardware identifiers."""
+    components: List[str] = [
+        get_mac(),
+        get_cpu_id(),
+        get_disk_serial(),
+        platform.system(),
+        platform.node(),
+    ]
+    raw = "|".join(components)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+SYSTEM_FINGERPRINT = generate_fingerprint()

--- a/tests/unit_tests/test_auth.py
+++ b/tests/unit_tests/test_auth.py
@@ -1,0 +1,161 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# Create a lightweight stub for the top-level skyvern package to avoid heavy imports
+skyvern_stub = types.ModuleType("skyvern")
+skyvern_stub.__path__ = [str(Path(__file__).resolve().parents[2] / "skyvern")]
+sys.modules["skyvern"] = skyvern_stub
+forge_stub = types.ModuleType("skyvern.forge")
+app_stub = types.ModuleType("skyvern.forge.app")
+forge_stub.app = app_stub
+forge_stub.__path__ = [str(Path(__file__).resolve().parents[2] / "skyvern/forge")]
+sys.modules["skyvern.forge"] = forge_stub
+sys.modules["skyvern.forge.app"] = app_stub
+
+openai_stub = types.ModuleType("openai")
+openai_types_stub = types.ModuleType("openai.types")
+openai_responses_stub = types.ModuleType("openai.types.responses")
+openai_response_stub = types.ModuleType("openai.types.responses.response")
+openai_response_stub.Response = object
+sys.modules["openai"] = openai_stub
+sys.modules["openai.types"] = openai_types_stub
+sys.modules["openai.types.responses"] = openai_responses_stub
+sys.modules["openai.types.responses.response"] = openai_response_stub
+class _OpenAIClient:
+    pass
+openai_stub.AsyncOpenAI = _OpenAIClient
+openai_stub.AsyncAzureOpenAI = _OpenAIClient
+
+anthropic_stub = types.ModuleType("anthropic")
+class _AnthropicAsync:
+    pass
+
+anthropic_stub.AsyncAnthropic = _AnthropicAsync
+anthropic_stub.AsyncAnthropicBedrock = _AnthropicAsync
+sys.modules["anthropic"] = anthropic_stub
+
+playwright_stub = types.ModuleType("playwright")
+impl_stub = types.ModuleType("playwright._impl")
+errors_stub = types.ModuleType("playwright._impl._errors")
+class TargetClosedError(Exception):
+    pass
+errors_stub.TargetClosedError = TargetClosedError
+class TimeoutError(Exception):
+    pass
+errors_stub.TimeoutError = TimeoutError
+sys.modules["playwright"] = playwright_stub
+sys.modules["playwright._impl"] = impl_stub
+sys.modules["playwright._impl._errors"] = errors_stub
+async_api_stub = types.ModuleType("playwright.async_api")
+class Page:
+    pass
+async_api_stub.Page = Page
+class ElementHandle:
+    pass
+async_api_stub.ElementHandle = ElementHandle
+class Frame:
+    pass
+async_api_stub.Frame = Frame
+class Locator:
+    pass
+async_api_stub.Locator = Locator
+sys.modules["playwright.async_api"] = async_api_stub
+
+alembic_stub = types.ModuleType("alembic")
+command_stub = types.ModuleType("alembic.command")
+sys.modules["alembic"] = alembic_stub
+sys.modules["alembic.command"] = command_stub
+config_stub = types.ModuleType("alembic.config")
+class Config:
+    pass
+config_stub.Config = Config
+sys.modules["alembic.config"] = config_stub
+
+litellm_stub = types.ModuleType("litellm")
+class _ConfigDict(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+litellm_stub.ConfigDict = _ConfigDict
+sys.modules["litellm"] = litellm_stub
+
+from skyvern.forge import app as app_module
+from skyvern.forge.sdk.db.client import AgentDB
+from skyvern.forge.sdk.db.models import Base
+from skyvern.forge.sdk.routes import auth as _  # noqa: F401
+from skyvern.forge.sdk.routes.routers import base_router
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_org_roundtrip() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db = AgentDB("sqlite+aiosqlite:///:memory:", db_engine=engine)
+    first = await db.get_or_create_user_org("bob")
+    second = await db.get_or_create_user_org("bob")
+    assert first.organization_id == second.organization_id
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_org_sequential() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db = AgentDB("sqlite+aiosqlite:///:memory:", db_engine=engine)
+    first = await db.get_or_create_user_org("alice")
+    second = await db.get_or_create_user_org("charlie")
+    assert first.organization_id != second.organization_id
+    assert first.organization_name == "organization-1"
+    assert second.organization_name == "organization-2"
+
+
+def test_license_login(monkeypatch) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(setup())
+
+    db = AgentDB("sqlite+aiosqlite:///:memory:", db_engine=engine)
+    app_module.DATABASE = db
+
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(base_router)
+    client = TestClient(fastapi_app)
+
+    import httpx
+
+    def fake_post(url, json, timeout=10.0):
+        class Resp:
+            def json(self):
+                return {
+                    "valid": "True",
+                    "user": {"email": "alice@example.com", "name": "Alice"},
+                }
+
+        return Resp()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    resp = client.post("/auth/login", json={"license_key": "abc"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "access_token" in body
+    assert body["organizationID"] == "organization-1"
+
+    resp2 = client.post("/auth/login", json={"license_key": "abc"})
+    assert resp2.status_code == 200
+    assert resp2.json()["organizationID"] == body["organizationID"]


### PR DESCRIPTION
## Summary
- implement license-key authentication that validates against an external licensing server and provisions user organizations automatically
- introduce a public landing page, license key login UI, and registration instructions pointing to the licensing portal
- document license-based onboarding and configure Docker build-time and runtime variables for the licensing server

## Testing
- `pre-commit run --all-files` *(fails: command not found: pre-commit)*
- `pytest tests/unit_tests/test_auth.py` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_6891168f60e4832b942b700ec7041199