### PR TITLE
Guard Alembic check until migration succeeds

### DIFF
--- a/entrypoint-skyvern.sh
+++ b/entrypoint-skyvern.sh
@@ -3,7 +3,10 @@
 set -e
 
 # check alembic
-alembic upgrade head
+if ! alembic upgrade head; then
+    echo "Alembic upgrade failed" >&2
+    exit 1
+fi
 alembic check
 
 if [ ! -f ".streamlit/secrets.toml" ]; then


### PR DESCRIPTION
## Summary
- ensure `entrypoint-skyvern.sh` only runs `alembic check` after a successful `alembic upgrade head`

## Testing
- `poetry run alembic heads`
- `poetry run alembic current 2>&1 | tail -n 5` *(fails: connection refused)*
- `poetry run alembic upgrade head 2>&1 | tail -n 5` *(fails: connection refused)*
- `poetry run pre-commit run --all-files` *(fails: mypy missing return statements; shellcheck requires docker)*


------
https://chatgpt.com/codex/tasks/task_e_68963b07511c832b8ec15465c9e3899a