### PR TITLE
[UI] Add license validation flow

### DIFF
--- a/skyvern-frontend/src/routes/login/LoginPage.tsx
+++ b/skyvern-frontend/src/routes/login/LoginPage.tsx
@@ -1,7 +1,10 @@
+import axios from "axios";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getClient } from "@/api/AxiosClient";
 import { useAuthStore } from "@/store/AuthStore";
+import { licenseServerUrl } from "@/util/env";
+import { generateMachineId } from "@/util/machineFingerprint";
 
 function LoginPage() {
   const [licenseKey, setLicenseKey] = useState("");
@@ -10,6 +13,20 @@ function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const machineId = generateMachineId();
+    const payload = {
+      licenseKey,
+      machineId,
+      productId: 1,
+    };
+    const { data: licenseData } = await axios.post(
+      `${licenseServerUrl}/api/license/validate`,
+      payload,
+    );
+    if (String(licenseData.valid).toLowerCase() !== "true") {
+      alert("Invalid license");
+      return;
+    }
     const client = await getClient(null);
     const { data } = await client.post("/auth/login", {
       license_key: licenseKey,

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -19,6 +19,12 @@ if (!artifactApiBaseUrl) {
   console.warn("artifactApiBaseUrl environment variable was not set");
 }
 
+const licenseServerUrl = import.meta.env.VITE_LICENSE_SERVER_URL;
+
+if (!licenseServerUrl) {
+  console.warn("licenseServerUrl environment variable was not set");
+}
+
 const apiPathPrefix = import.meta.env.VITE_API_PATH_PREFIX ?? "";
 
 const lsKeys = {
@@ -43,6 +49,7 @@ export {
   environment,
   envCredential,
   artifactApiBaseUrl,
+  licenseServerUrl,
   apiPathPrefix,
   lsKeys,
   wssBaseUrl,

--- a/skyvern-frontend/src/util/machineFingerprint.ts
+++ b/skyvern-frontend/src/util/machineFingerprint.ts
@@ -1,0 +1,76 @@
+/* eslint-env node */
+import os from "os";
+import crypto from "crypto";
+import { execSync } from "child_process";
+
+function getMac(): string {
+  const interfaces = os.networkInterfaces();
+  for (const key of Object.keys(interfaces)) {
+    const iface = interfaces[key];
+    if (!iface) continue;
+    for (const info of iface) {
+      if (info.mac && info.mac !== "00:00:00:00:00:00") {
+        return info.mac;
+      }
+    }
+  }
+  return "unknown-mac";
+}
+
+function getCpuId(): string {
+  try {
+    const platform = os.platform();
+    if (platform === "win32") {
+      const result = execSync("wmic cpu get ProcessorId").toString();
+      return result.split("\n")[1].trim();
+    }
+    if (platform === "linux") {
+      const result = execSync("cat /proc/cpuinfo | grep Serial").toString();
+      return result.split(":")[1].trim();
+    }
+    if (platform === "darwin") {
+      const result = execSync("sysctl -n machdep.cpu.brand_string").toString();
+      return result.trim();
+    }
+  } catch {
+    /* empty */
+  }
+  return "unknown-cpu";
+}
+
+function getDiskSerial(): string {
+  try {
+    const platform = os.platform();
+    if (platform === "win32") {
+      const result = execSync("wmic diskdrive get SerialNumber").toString();
+      return result.split("\n")[1].trim();
+    }
+    if (platform === "linux") {
+      const result = execSync(
+        "hdparm -I /dev/sda | grep 'Serial Number'",
+      ).toString();
+      return result.split(":")[1].trim();
+    }
+    if (platform === "darwin") {
+      const result = execSync(
+        "system_profiler SPStorageDataType | grep 'Serial Number'",
+      ).toString();
+      return result.split(":")[1].trim();
+    }
+  } catch {
+    /* empty */
+  }
+  return "unknown-disk";
+}
+
+export function generateMachineId(): string {
+  const components = [
+    getMac(),
+    getCpuId(),
+    getDiskSerial(),
+    os.platform(),
+    os.hostname(),
+  ];
+  const raw = components.join("|");
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}

--- a/skyvern/utils/fingerprint.py
+++ b/skyvern/utils/fingerprint.py
@@ -8,7 +8,7 @@ from typing import List
 def get_mac() -> str:
     """Return the device MAC address."""
     mac = uuid.getnode()
-    return ":".join(f"{(mac >> ele) & 0xff:02x}" for ele in range(40, -1, -8))
+    return ":".join(f"{(mac >> ele) & 0xFF:02x}" for ele in range(40, -1, -8))
 
 
 def get_cpu_id() -> str:
@@ -19,17 +19,14 @@ def get_cpu_id() -> str:
             result = subprocess.check_output(["wmic", "cpu", "get", "ProcessorId"]).decode()
             return result.strip().split("\n")[1].strip()
         if system == "Linux":
-            result = subprocess.check_output(
-                "cat /proc/cpuinfo | grep Serial", shell=True
-            ).decode()
+            result = subprocess.check_output("cat /proc/cpuinfo | grep Serial", shell=True).decode()
             return result.strip().split(":")[1].strip()
         if system == "Darwin":
-            result = subprocess.check_output(
-                ["sysctl", "-n", "machdep.cpu.brand_string"]
-            ).decode()
+            result = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode()
             return result.strip()
     except Exception:
         return "unknown-cpu"
+    return "unknown-cpu"
 
 
 def get_disk_serial() -> str:
@@ -41,9 +38,7 @@ def get_disk_serial() -> str:
             lines = result.strip().split("\n")
             return lines[1].strip()
         if system == "Linux":
-            result = subprocess.check_output(
-                "hdparm -I /dev/sda | grep 'Serial Number'", shell=True
-            ).decode()
+            result = subprocess.check_output("hdparm -I /dev/sda | grep 'Serial Number'", shell=True).decode()
             return result.strip().split(":")[1].strip()
         if system == "Darwin":
             result = subprocess.check_output(
@@ -53,6 +48,7 @@ def get_disk_serial() -> str:
             return result.strip().split(":")[1].strip()
     except Exception:
         return "unknown-disk"
+    return "unknown-disk"
 
 
 def generate_fingerprint() -> str:


### PR DESCRIPTION
## Summary
- validate licenses against remote server before creating session
- generate machine fingerprint to send with license validation
- expose license server url via frontend env utils
- ensure backend fingerprint helper always returns a value

## Testing
- `pre-commit run --files skyvern-frontend/src/routes/login/LoginPage.tsx skyvern-frontend/src/util/env.ts skyvern-frontend/src/util/machineFingerprint.ts skyvern/utils/fingerprint.py`


------
https://chatgpt.com/codex/tasks/task_e_689764a73590832b98a0e6789ec7523a