### PR TITLE
[Frontend] Fix: handle undefined machine fingerprint components

### DIFF
--- a/skyvern-frontend/src/util/machineFingerprint.ts
+++ b/skyvern-frontend/src/util/machineFingerprint.ts
@@ -22,11 +22,11 @@ function getCpuId(): string {
     const platform = os.platform();
     if (platform === "win32") {
       const result = execSync("wmic cpu get ProcessorId").toString();
-      return result.split("\n")[1].trim();
+      return result.split("\n")[1]?.trim() ?? "unknown-cpu";
     }
     if (platform === "linux") {
       const result = execSync("cat /proc/cpuinfo | grep Serial").toString();
-      return result.split(":")[1].trim();
+      return result.split(":")[1]?.trim() ?? "unknown-cpu";
     }
     if (platform === "darwin") {
       const result = execSync("sysctl -n machdep.cpu.brand_string").toString();
@@ -43,19 +43,19 @@ function getDiskSerial(): string {
     const platform = os.platform();
     if (platform === "win32") {
       const result = execSync("wmic diskdrive get SerialNumber").toString();
-      return result.split("\n")[1].trim();
+      return result.split("\n")[1]?.trim() ?? "unknown-disk";
     }
     if (platform === "linux") {
       const result = execSync(
         "hdparm -I /dev/sda | grep 'Serial Number'",
       ).toString();
-      return result.split(":")[1].trim();
+      return result.split(":")[1]?.trim() ?? "unknown-disk";
     }
     if (platform === "darwin") {
       const result = execSync(
         "system_profiler SPStorageDataType | grep 'Serial Number'",
       ).toString();
-      return result.split(":")[1].trim();
+      return result.split(":")[1]?.trim() ?? "unknown-disk";
     }
   } catch {
     /* empty */


### PR DESCRIPTION
## Summary
- guard against missing split parts in `machineFingerprint` utility

## Testing
- `npx tsc --noEmit`
- `pre-commit run --all-files` *(fails: tests/unit_tests/test_auth.py:177:5: PLC0415 import should be at the top-level of a file)*

------
https://chatgpt.com/codex/tasks/task_e_6897694ec6b4832b8e80719444d817f9