### PR TITLE
fix: derive host system machine fingerprint

### DIFF
--- a/entrypoint-skyvernui.sh
+++ b/entrypoint-skyvernui.sh
@@ -5,6 +5,9 @@ set -e
 # setting api key
 VITE_SKYVERN_API_KEY=$(sed -n 's/.*cred\s*=\s*"\([^"]*\)".*/\1/p' .streamlit/secrets.toml)
 export VITE_SKYVERN_API_KEY
+# compute system fingerprint for license validation
+VITE_SYSTEM_FINGERPRINT=$(python -c 'from skyvern.utils.fingerprint import SYSTEM_FINGERPRINT; print(SYSTEM_FINGERPRINT)')
+export VITE_SYSTEM_FINGERPRINT
 npm run start
 
 

--- a/skyvern-frontend/src/util/machineFingerprint.ts
+++ b/skyvern-frontend/src/util/machineFingerprint.ts
@@ -1,76 +1,9 @@
-/* eslint-env node */
-import os from "os";
-import crypto from "crypto";
-import { execSync } from "child_process";
-
-function getMac(): string {
-  const interfaces = os.networkInterfaces();
-  for (const key of Object.keys(interfaces)) {
-    const iface = interfaces[key];
-    if (!iface) continue;
-    for (const info of iface) {
-      if (info.mac && info.mac !== "00:00:00:00:00:00") {
-        return info.mac;
-      }
-    }
-  }
-  return "unknown-mac";
-}
-
-function getCpuId(): string {
-  try {
-    const platform = os.platform();
-    if (platform === "win32") {
-      const result = execSync("wmic cpu get ProcessorId").toString();
-      return result.split("\n")[1]?.trim() ?? "unknown-cpu";
-    }
-    if (platform === "linux") {
-      const result = execSync("cat /proc/cpuinfo | grep Serial").toString();
-      return result.split(":")[1]?.trim() ?? "unknown-cpu";
-    }
-    if (platform === "darwin") {
-      const result = execSync("sysctl -n machdep.cpu.brand_string").toString();
-      return result.trim();
-    }
-  } catch {
-    /* empty */
-  }
-  return "unknown-cpu";
-}
-
-function getDiskSerial(): string {
-  try {
-    const platform = os.platform();
-    if (platform === "win32") {
-      const result = execSync("wmic diskdrive get SerialNumber").toString();
-      return result.split("\n")[1]?.trim() ?? "unknown-disk";
-    }
-    if (platform === "linux") {
-      const result = execSync(
-        "hdparm -I /dev/sda | grep 'Serial Number'",
-      ).toString();
-      return result.split(":")[1]?.trim() ?? "unknown-disk";
-    }
-    if (platform === "darwin") {
-      const result = execSync(
-        "system_profiler SPStorageDataType | grep 'Serial Number'",
-      ).toString();
-      return result.split(":")[1]?.trim() ?? "unknown-disk";
-    }
-  } catch {
-    /* empty */
-  }
-  return "unknown-disk";
-}
-
+/**
+ * Return the fingerprint of the machine hosting the Skyvern UI.
+ *
+ * The value is injected at build time via the `VITE_SYSTEM_FINGERPRINT`
+ * environment variable and should uniquely identify the host system.
+ */
 export function generateMachineId(): string {
-  const components = [
-    getMac(),
-    getCpuId(),
-    getDiskSerial(),
-    os.platform(),
-    os.hostname(),
-  ];
-  const raw = components.join("|");
-  return crypto.createHash("sha256").update(raw).digest("hex");
+  return import.meta.env.VITE_SYSTEM_FINGERPRINT ?? "unknown-machine";
 }


### PR DESCRIPTION
## Summary
- read machine fingerprint from `VITE_SYSTEM_FINGERPRINT` environment variable
- compute and export host fingerprint in UI entrypoint script

## Testing
- `npm run lint`
- `VITE_SYSTEM_FINGERPRINT=test npm run build`
- `pre-commit run --all-files` *(fails: Executable `docker` not found for ShellCheck)*

------
https://chatgpt.com/codex/tasks/task_e_68976fd9016c832b9e3fe420ac2ed48e